### PR TITLE
Remove magic command that causes error when running from command line 

### DIFF
--- a/Playlister/Train.py
+++ b/Playlister/Train.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import numpy as np
 import matplotlib.pyplot as plt
-%matplotlib inline
+
 import pickle
 import os
 # Preprocessing


### PR DESCRIPTION
The IPython magic command in Train.py causes an error when run with regular python interpreter, so have deleted that line.